### PR TITLE
Don't publish /src/js folder to npm because we want npm versions of components to use the dist folder.

### DIFF
--- a/lib/skeletons.js
+++ b/lib/skeletons.js
@@ -5,6 +5,7 @@ export let componentManifest = {
 		"dist/",
 		"index.js",
 		"src/",
+		"!src/js/",
 		"main*",
 		"img",
 		"*.json",


### PR DESCRIPTION
When migrating the ft-app they noticed an increase in their bundle size due to using both the dist and the src folders.