### PR TITLE
Remove "ftdomdelegate" from component mappings.

### DIFF
--- a/config/mappings.js
+++ b/config/mappings.js
@@ -1,7 +1,6 @@
 export default {
 	name: {
 		"ft-date-format": "@financial-times/ft-date-format",
-		ftdomdelegate: "dom-delegate",
 		prism: "prismjs",
 		pusher: "pusher-js",
 		hogan: "hogan.js"


### PR DESCRIPTION
Versions 2.2.1 and above of `dom-delegate` have been published to
NPM as `ftdomdelegate`.

https://www.npmjs.com/package/ftdomdelegate
https://www.npmjs.com/package/dom-delegate

I'm releasing component majors to upgrade them to the new 
`ftdomdelegate@v3.0.0` major, so I don't _think_ we need to worry 
about `ftdomdelegate` and `dom-delegate`  being included at 
the same time.