### PR TITLE
Make dependabot ignore updates to o-spec-compliant-bower-config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
       - "dependencies"
     ignore:
       - dependency-name: "snyk"
+      - dependency-name: "o-spec-compliant-bower-config"
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
o-spec-compliant-bower-config  is an alias to o-test-component.
o-test-component is now an origami spec v2 component and because of that, it will no longer work with origami-component-converter.
origami-component-converter will not be updated to work with origami spec v2 components as the new components are built for npm, which obviates the need for origami-component-converter